### PR TITLE
Remove redundant package from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "symfony/form": "~2.1",
         "symfony/security": "~2.1",
         "doctrine/common": "~2.2",
-        "doctrine/orm": "~2.2",
-        "doctrine/dbal": "~2.2"
+        "doctrine/orm": "~2.2"
     }
 }


### PR DESCRIPTION
You can remove `doctrine/dbal` package from `composer.json` as `doctrine/orm` already contains it in its requirements.